### PR TITLE
Mobile update

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="description" content="">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
     
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic' rel='stylesheet' type='text/css'>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -522,9 +522,11 @@ button:active,
 }
 .page-section {
   padding: 4em 0 3em;
+    overflow: hidden;
 }
 .page-section:nth-child(odd) {
   background: #f6f6f6;
+  text-align: center;
 }
 .section__title {
   text-align: center;
@@ -562,6 +564,7 @@ img {
   height: 1.5em;
   float: left;
   padding: 1.5em 0;
+  text-align: center;
 }
 .masthead .logo img {
   max-height: 100%;
@@ -578,6 +581,7 @@ img {
   list-style: none;
   display: block;
   float: left;
+  text-align: center;
 }
 .menu a {
   display: block;
@@ -851,3 +855,65 @@ table{
   table-layout:fixed;
 }
 
+/* ==========================================================================
+   =MOBILE
+   ========================================================================== */
+body, html {
+    /*Fixes an issue with unwanted horizontal scrolling on the whole page*/
+    max-width: 100%;
+    overflow-x: hidden;
+}
+@media (max-width: 60em) {
+    .menu li {
+        width:33.3333%;
+    }
+    .logo {
+        width:100%;   
+    }
+    .masthead {
+        position:relative;   
+    }
+    #map iframe {
+        height: 300px;
+    }
+    .animated {
+        -webkit-animation-name: none;
+        animation-name: none;
+    }
+}
+@media (max-width: 45em) {
+    .menu li {
+        width:50%;
+    }
+}
+@media (max-width: 30em) {
+    .person {
+        height: 100px;   
+    }
+    .person__img {
+        width: 25%;
+        float: left;
+        overflow: visible;
+    }
+    .person__name {
+        text-align: right;   
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+    }
+    .person__img__info {
+        opacity: 1;
+        background: none;
+        -webkit-transform:none;
+        transform: none;
+        width: 400%;
+    }
+    .person__img__info__cont {
+        position: absolute;
+        right: 0px;
+        top: auto;
+        bottom: -20px;
+        border-radius: 10px;
+        background-color: rgba(52, 152, 219, 0.5);   
+    }
+}


### PR DESCRIPTION
This update adds a nicer looking mobile UI.

The navigation bar forms a 3-column display on devices with a width
of 60em or lower and a 2-column display on devices with a width of
45em or lower. It also becomes relatively positioned on devices 60em
or lower.

Demo:
![photo1](https://cloud.githubusercontent.com/assets/4087148/5429607/e7c5a8f2-83b6-11e4-8f1c-7c28df8d93bd.jpg)

Animations are disabled on devices with a width of 60em or lower
because the window.onScroll method is only triggered on mobile devices
when the user releases their finger. Because of this, animations
look buggy on mobile devices.

People with pictures and links on the website form a tableview display
on devices with a width of 30em and lower. This makes it easy for people on
mobile devices to scroll through more content quicker and view the links
easier.

Demo:
![photo2](https://cloud.githubusercontent.com/assets/4087148/5429606/e7c246e4-83b6-11e4-8aa7-72de5281651b.jpg)

It might be useful if someone could figure out how to change the height of
the title banner on mobile devices.
