### PR TITLE
Changing README to remove testing with Mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ There you can see guidelines: http://www.google-melange.com/gci/task/view/google
 
 1. Go to the folder using `cd fossasia.github.io` command
 
-1. Copy your photo to `images/students` directory rescaling it before (to size about 300px * 300px). If the image isn't exactly square, it cannot be accepted. Please ensure a lowercase extension (`jpg` instead of `JPG`).
-
-1. Run the imageSize test. You'll need to install [Mocha](http://mochajs.org/) and [nodejs](http://nodejs.org/) for the tests. In the `fossasia.github.io` directory, first run `npm install` to install the needed dependencies. Then run the test by typing `mocha tests/imageSize`. If the test passes, you'll see two ticks. If it fails, please modify the image you have added for it to have an equal height and width. The pull request cannot be accepted if this test fails.
+1. Copy your photo to `images/students` directory rescaling it before (to size about 300px * 300px). **If the image isn't exactly square, it cannot be accepted.** Please ensure a lowercase extension (`jpg` instead of `JPG`).
 
 1. Enter command `git add images/students/nameofyourphoto.yourfilextenstion` into the command line.
 


### PR DESCRIPTION
Do we remove the Mocha testing bit since the test will be an in-browser one in the future? Noticed a student struggling with this step. I've bolded the step which said that the image needs to be exactly square. What do you think?
