### PR TITLE
Adding travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+
+before_install:
+  - gem install github-pages --no-rdoc --no-ri
+
+script:
+  - ./node_modules/.bin/mocha tests/
+  - jekyll build

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "bugs": {
     "url": "https://github.com/fossasia/fossasia.github.io/issues"
   },
-  "homepage": "http://fossasia.github.io"
+  "homepage": "http://fossasia.github.io",
+  "devDependencies": {
+    "mocha": "*",
+    "image-size": "*"
+  }
 }


### PR DESCRIPTION
We can use [travis-ci](https://github.com/travis-ci/travis-ci) for running our tests on travis cloud. Currently we have a nice little test to check if the dimensions of images are valid (Thanks @namangoel1!!). We will try if this works and expand those tests. 
